### PR TITLE
Padding option

### DIFF
--- a/js/Genoverse.js
+++ b/js/Genoverse.js
@@ -10,7 +10,7 @@ var Genoverse = Base.extend({
   defaultScrollDelta : 100,
   tracks             : [],
   plugins            : [],
-  padding            : 0,
+  padding            : 0, 
   dragAction         : 'scroll', // options are: scroll, select, off
   wheelAction        : 'off',    // options are: zoom, off
   isStatic           : false,    // if true, will stop drag, select and zoom actions occurring
@@ -161,7 +161,7 @@ var Genoverse = Base.extend({
     this.addTracks();
 	
     if (typeof this.padding === 'number' && this.padding % 1 === 0) {
-		this.setRange(coords.start - this.padding, coords.end + this.padding, true);
+		this.setRange(coords.start - this.padding, coords.end + this.padding);
 	} else {
 		this.setRange(coords.start, coords.end);
 	}


### PR DESCRIPTION
Dunno if this is useful, or indeed if it's already a feature and I've just ignored it!

Anyway, I've added a 'padding' option to the default config, which is then interpreted at the init() function, with any initial coordinates giving a set padding either side (so if we zoom in on 1:68903942 with padding set to '5', it will show the region 1:68903937-68903947)
