### PR TITLE
enable presigned S3 URL for BAM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /data*
 *.DS_Store
-
+node_modules/*
+.idea/*
+*.tgz

--- a/js/Track/Model/File/BAM.js
+++ b/js/Track/Model/File/BAM.js
@@ -6,7 +6,11 @@ Genoverse.Track.Model.File.BAM = Genoverse.Track.Model.File.extend({
     if (!this.bamFile) {
       if (this.url) {
         this.bamFile = new dallianceLib.URLFetchable(this.url);
-        this.baiFile = new dallianceLib.URLFetchable(this.url + this.prop('indexExt'));
+        if (this.bai) {
+          this.baiFile = new dallianceLib.URLFetchable(this.bai);
+        } else {
+          this.baiFile = new dallianceLib.URLFetchable(this.url + this.prop('indexExt'));
+        }
       } else if (this.dataFile && this.indexFile) {
         this.bamFile = new dallianceLib.BlobFetchable(this.dataFile);
         this.baiFile = new dallianceLib.BlobFetchable(this.indexFile);


### PR DESCRIPTION
The way S3 generates pre-signed URIs requires a way to provide both url and bai to the track. This is a simple way to do so.