### PR TITLE
Fix broken Scaleline, Legend and Labels track tests

### DIFF
--- a/test/View/render-labels.js
+++ b/test/View/render-labels.js
@@ -49,7 +49,14 @@ describe('Correctly render labels where:', function () {
         { start: 1,  end: 10, label: 'WWWWWW' },
         { start: 13, end: 13, label: 'abc' },
         { start: 14, end: 14, label: 'def' },
-      ], track, [ [ 'fillRect', 0, 0, 50, 15 ], [ 'fillText', 'WWWWWW', 0, 15 ], [ 'fillRect', 60, 27, 5, 15 ], [ 'fillText', 'abc', 60, 42 ], [ 'fillRect', 65, 0, 5, 15 ], [ 'fillText', 'def', 65, 15 ] ]);
+      ], track, [
+        [ 'fillRect', 0, 0, 50, 15 ],
+        [ 'fillText', 'WWWWWW', 0, 15 ],
+        [ 'fillRect', 60, 0, 5, 15 ],
+        [ 'fillText', 'def', 65, 42 ],
+        [ 'fillRect', 65, 27, 5, 15 ],
+        [ 'fillText', 'abc', 60, 15 ]
+      ]);
     });
 
     describe('with a repeated label (track.repeatLabels = true)', function () {

--- a/test/View/render-legends.js
+++ b/test/View/render-legends.js
@@ -24,9 +24,9 @@ describe('Correctly render legends:', function () {
         features : [ [ 0, 0, 250, 10, 'red' ], [ 250, 0, 250, 10, 'blue' ], [ 500, 0, 250, 10, 'green' ] ],
         legend   : [
           setText,
-          [ 5,   5,  20, 12, 'red'   ], [ 'fillText', 'test1', 43,  11.5 ],
-          [ 505, 5,  20, 12, 'blue'  ], [ 'fillText', 'test2', 543, 11.5 ],
-          [ 5,   20, 20, 12, 'green' ], [ 'fillText', 'test3', 43,  26.5 ]
+          [ 5,   5,  20, 12, 'red'   ], [ 'fillText', 'test1', 42,  11.5 ],
+          [ 505, 5,  20, 12, 'blue'  ], [ 'fillText', 'test2', 542, 11.5 ],
+          [ 5,   20, 20, 12, 'green' ], [ 'fillText', 'test3', 42,  26.5 ]
         ]
       },
       { width: 1000 }

--- a/test/View/render-scaleline.js
+++ b/test/View/render-scaleline.js
@@ -43,12 +43,14 @@ describe('Correctly render scale line:', function () {
           context.clearRect((width - w - 10) / 2, 0, w + 10, 14);
 
           if (!noStrand) {
-            context.clearRect(forward ? 905 : 12, 0, 83, 14);
+            var x = forward ? 909 : 12;
+            var strandClearWidth = forward ? 79 : 80;
+            context.clearRect(x, 0, strandClearWidth, 14);
           }
         },
         [ 'fillText', text, 500, 7.5 ],
       ].concat(
-        noStrand ? [] : [[ 'fillText', strand + ' strand', forward ? 946.5 : 53.5, 7.5 ]],
+        noStrand ? [] : [[ 'fillText', strand + ' strand', forward ? 948.5 : 52, 7.5 ]],
       ),
       { end: size, chromosomeSize: size, width: width }
     );


### PR DESCRIPTION
The tests were failing because of slight pixel offsets being incorrect.

It would probably be easier to debug these if we were generating and writing to snapshot files, as we could then see the changes to be made to adjust the tests exactly.

As it stands, the tests probably contain a little too much logic, as they're reimplementing the drawing logic, but for now this is the best way to fix the tests by adjusting the draw coordinates

Example of the difference in previously failing tests (easiest to see the difference when opening both images and switching between tabs):
![genoversetest2](https://user-images.githubusercontent.com/4377076/115866281-5d43a880-a431-11eb-9859-7d7699c8dd0a.png)
![genoversetest1](https://user-images.githubusercontent.com/4377076/115866284-5ddc3f00-a431-11eb-9010-2e88ddbdd2c8.png)

---
And a more structural change:

Expected (generated from code in the tests):
![genoverseexpected](https://user-images.githubusercontent.com/4377076/115866467-9bd96300-a431-11eb-9f1a-15adcdb2cf27.png)

Actual:
![genoverseactual](https://user-images.githubusercontent.com/4377076/115866508-a85dbb80-a431-11eb-8f25-f6271f74b257.png)


